### PR TITLE
Rename getFlightReply API method

### DIFF
--- a/src/hooks/useChatbot.ts
+++ b/src/hooks/useChatbot.ts
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react"
 import { v4 as uuidv4 } from "uuid"
 import { WelcomeMessage } from "@/data/ChatbotConfig"
 import { useLanguage } from "@/context/LanguageContext"
-import { getFlightReply } from "@/lib/api"
+import { getLegalReply } from "@/lib/api"
 
 type ChatMessage = {
   role: "user" | "assistant"
@@ -29,7 +29,7 @@ export function useChatbot(currency: string) {
     addMessage("assistant", "__TYPING__")
 
     try {
-      const reply = await getFlightReply({ query: text, sessionId, currency })
+      const reply = await getLegalReply({ query: text, sessionId, currency })
       setMessages(prev => {
         const updated = [...prev]
         const last = updated.length - 1
@@ -43,7 +43,7 @@ export function useChatbot(currency: string) {
         const updated = [...prev]
         const last = updated.length - 1
         if (updated[last].role === "assistant" && updated[last].content === "__TYPING__") {
-          updated[last] = { role: "assistant", content: "❌ Sorry, I couldn't reach the flight server." }
+          updated[last] = { role: "assistant", content: "❌ Sorry, I couldn't reach the legal assistant server." }
         }
         return updated
       })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,11 +7,11 @@ async function getApiEndpoint(): Promise<string> {
   const config = await res.json();
   apiEndpoint = config.apiEndpoint;
 
-  if (!apiEndpoint) throw new Error("Missing API endpoint in config");
+  if (!apiEndpoint) throw new Error("Missing legal assistant backend endpoint in config");
   return apiEndpoint;
 }
 
-export async function getFlightReply({
+export async function getLegalReply({
   query,
   sessionId,
   currency,


### PR DESCRIPTION
## Summary
- rename `getFlightReply` to `getLegalReply`
- update error messages to refer to the legal assistant backend

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-unused-vars in existing files)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68405a1ed97c8324a7dd13ea35ce4e7e