### PR TITLE
Improve API error handling

### DIFF
--- a/src/hooks/useChatbot.ts
+++ b/src/hooks/useChatbot.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react"
 import { v4 as uuidv4 } from "uuid"
-import { WelcomeMessage, NetworkErrorMessage } from "@/data/ChatbotConfig"
+import { WelcomeMessage } from "@/data/ChatbotConfig"
 import { useLanguage } from "@/context/LanguageContext"
 import { getLegalReply } from "@/lib/api"
 
@@ -28,28 +28,15 @@ export function useChatbot() {
     addMessage("user", text)
     addMessage("assistant", "__TYPING__")
 
-    try {
-      const reply = await getLegalReply({ query: text, sessionId })
-      setMessages(prev => {
-        const updated = [...prev]
-        const last = updated.length - 1
-        if (updated[last].role === "assistant" && updated[last].content === "__TYPING__") {
-          updated[last] = { role: "assistant", content: reply }
-        }
-        return updated
-      })
-    } catch {
-      setMessages(prev => {
-        const updated = [...prev]
-        const last = updated.length - 1
-        if (updated[last].role === "assistant" && updated[last].content === "__TYPING__") {
-
-          updated[last] = { role: "assistant", content: NetworkErrorMessage[lang] }
-
-        }
-        return updated
-      })
-    }
+    const reply = await getLegalReply({ query: text, sessionId, lang })
+    setMessages(prev => {
+      const updated = [...prev]
+      const last = updated.length - 1
+      if (updated[last].role === "assistant" && updated[last].content === "__TYPING__") {
+        updated[last] = { role: "assistant", content: reply }
+      }
+      return updated
+    })
   }
 
   return { messages, addMessage, handleUserMessage, setSessionId }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,34 +1,53 @@
+import { NetworkErrorMessage } from "@/data/ChatbotConfig";
+
+type Language = "en" | "fr" | "ar";
+
 let apiEndpoint: string | null = null;
 
 async function getApiEndpoint(): Promise<string> {
   if (apiEndpoint) return apiEndpoint;
 
-  const res = await fetch("/api-config.json");
-  const config = await res.json();
-  apiEndpoint = config.apiEndpoint;
+  try {
+    const res = await fetch("/api-config.json");
+    const config = await res.json();
+    apiEndpoint = config.apiEndpoint;
 
-  if (!apiEndpoint) throw new Error("Missing legal assistant backend endpoint in config");
-  return apiEndpoint;
+    if (!apiEndpoint) throw new Error("Missing legal assistant backend endpoint in config");
+    return apiEndpoint;
+  } catch (err) {
+    console.error("Error fetching API endpoint:", err);
+    throw err;
+  }
 }
 
 export async function getLegalReply({
   query,
   sessionId,
+  lang,
 }: {
   query: string;
   sessionId: string;
+  lang: Language;
 }): Promise<string> {
-  const API_ENDPOINT = await getApiEndpoint();
+  try {
+    const API_ENDPOINT = await getApiEndpoint();
 
-  const res = await fetch(API_ENDPOINT, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sessionId, query }),
-  });
+    const res = await fetch(API_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sessionId, query }),
+    });
 
-  const data = await res.json();
-  console.log("API response:", data);
+    const data = await res.json();
+    console.log("API response:", data);
 
-  if (!res.ok) throw new Error("API call failed");
-  return data.answer || "⚠️ Empty answer received.";
+    if (!res.ok) {
+      console.error("API call failed", data);
+      return NetworkErrorMessage[lang];
+    }
+    return data.answer || "⚠️ Empty answer received.";
+  } catch (err) {
+    console.error("Error fetching legal reply:", err);
+    return NetworkErrorMessage[lang];
+  }
 }


### PR DESCRIPTION
## Summary
- handle network failures in `getLegalReply`
- simplify error handling in `useChatbot`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68418bbc28648324ab8a8a05e2b577fb