### PR TITLE
Add loading indicator with accessibility features

### DIFF
--- a/src/components/ChatMessages.tsx
+++ b/src/components/ChatMessages.tsx
@@ -1,5 +1,5 @@
 // src/components/ChatMessages.tsx
-import TypingDots from "./TypingDots"
+import TypingIndicator from "./TypingIndicator"
 import { useEffect, useRef } from "react"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import ReactMarkdown from "react-markdown"
@@ -7,21 +7,22 @@ import remarkGfm from "remark-gfm"
 
 export default function ChatMessages({
   messages,
+  isLoading,
 }: {
   messages: { role: "user" | "assistant"; content: string }[]
+  isLoading: boolean
 }) {
   const bottomRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" })
-  }, [messages])
+  }, [messages, isLoading])
 
   return (
     <ScrollArea className="flex-1 h-full px-4 py-6">
       <div className="flex flex-col gap-5 sm:gap-6">
         {messages.map((msg, i) => {
           const isUser = msg.role === "user"
-          const isTyping = msg.content === "__TYPING__"
 
           return (
             <div
@@ -35,10 +36,7 @@ export default function ChatMessages({
                     : "bg-gray-100 text-gray-700 rounded-tl-none border border-gray-200 shadow-sm dark:bg-gray-700 dark:text-gray-100 dark:border-gray-600"
                   }`}
               >
-                {isTyping ? (
-                  <TypingDots />
-                ) : (
-                  <div className="prose prose-sm sm:prose-base dark:prose-invert break-words leading-snug">
+                <div className="prose prose-sm sm:prose-base dark:prose-invert break-words leading-snug">
                   <ReactMarkdown
                     remarkPlugins={[[remarkGfm, { breaks: true }]]}
                     components={{
@@ -49,12 +47,17 @@ export default function ChatMessages({
                   >
                     {msg.content}
                   </ReactMarkdown>
-                  </div>
-                )}
+                </div>
               </div>
             </div>
           )
         })}
+
+        {isLoading && (
+          <div className="flex justify-center">
+            <TypingIndicator />
+          </div>
+        )}
 
         <div ref={bottomRef} />
       </div>

--- a/src/components/TypingIndicator.tsx
+++ b/src/components/TypingIndicator.tsx
@@ -1,0 +1,14 @@
+import TypingDots from "./TypingDots"
+
+export default function TypingIndicator() {
+  return (
+    <div
+      className="flex items-center justify-center px-4 py-2"
+      aria-label="Assistant is typing"
+      role="status"
+    >
+      <span className="sr-only">Assistant is typing</span>
+      <TypingDots />
+    </div>
+  )
+}

--- a/src/hooks/useChatbot.ts
+++ b/src/hooks/useChatbot.ts
@@ -14,6 +14,7 @@ export function useChatbot() {
   const [messages, setMessages] = useState<ChatMessage[]>([
   { role: "assistant", content: WelcomeMessage[lang] }])
   const [sessionId, setSessionId] = useState("")
+  const [isLoading, setIsLoading] = useState(false)
 
   useEffect(() => {
     setSessionId(uuidv4())
@@ -26,18 +27,12 @@ export function useChatbot() {
 
   const handleUserMessage = async (text: string) => {
     addMessage("user", text)
-    addMessage("assistant", "__TYPING__")
+    setIsLoading(true)
 
     const reply = await getLegalReply({ query: text, sessionId, lang })
-    setMessages(prev => {
-      const updated = [...prev]
-      const last = updated.length - 1
-      if (updated[last].role === "assistant" && updated[last].content === "__TYPING__") {
-        updated[last] = { role: "assistant", content: reply }
-      }
-      return updated
-    })
+    setMessages(prev => [...prev, { role: "assistant", content: reply }])
+    setIsLoading(false)
   }
 
-  return { messages, addMessage, handleUserMessage, setSessionId }
+  return { messages, isLoading, addMessage, handleUserMessage, setSessionId }
 }

--- a/src/pages/ChatbotPage.tsx
+++ b/src/pages/ChatbotPage.tsx
@@ -7,7 +7,7 @@ import { Separator } from "@/components/ui/separator"
 import { useChatbot } from "@/hooks/useChatbot"
 
 export default function ChatbotPage() {
-  const { messages, addMessage, handleUserMessage } = useChatbot()
+  const { messages, isLoading, addMessage, handleUserMessage } = useChatbot()
 
   return (
     <div className="h-dvh flex flex-col bg-gradient-to-br from-gray-50 to-gray-100 text-gray-800 dark:bg-gradient-to-br dark:from-gray-900 dark:to-gray-950 dark:text-gray-100">
@@ -17,7 +17,7 @@ export default function ChatbotPage() {
         <div className="w-full flex-1 flex flex-col min-h-0 bg-white dark:bg-gray-800 rounded-b-2xl shadow-xl border border-gray-100 dark:border-gray-700">
 
           <div className="flex-1 overflow-y-auto min-h-0">
-            <ChatMessages messages={messages} />
+            <ChatMessages messages={messages} isLoading={isLoading} />
           </div>
 
           <ChatSuggestionBar addMessage={addMessage} />


### PR DESCRIPTION
## Summary
- display a centered typing indicator while the assistant response loads
- make the indicator screen-reader friendly
- track loading state in `useChatbot` and pass it down

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6842311a3a1c8324a885520b7751047b